### PR TITLE
Bug fixes

### DIFF
--- a/src/krux/key.py
+++ b/src/krux/key.py
@@ -34,6 +34,7 @@ from .krux_settings import t
 
 DER_SINGLE = "m/84h/%dh/0h"
 DER_MULTI = "m/48h/%dh/0h/2h"
+HARDENED_STR_REPLACE = "'"
 
 
 class Key:
@@ -77,9 +78,11 @@ class Key:
         return formatted_txt % hexlify(self.fingerprint).decode("utf-8")
 
     def derivation_str(self, pretty=False):
-        """Returns the derivation path for the Hierarchical Deterministic Wallet"""
+        """Returns the derivation path for the Hierarchical Deterministic Wallet to
+        be displayed as string
+        """
         formatted_txt = t("Derivation: %s") if pretty else "%s"
-        return formatted_txt % self.derivation
+        return (formatted_txt % self.derivation).replace("h", HARDENED_STR_REPLACE)
 
     def sign(self, message_hash):
         """Signs a message with the extended master private key"""
@@ -104,3 +107,12 @@ class Key:
     def get_default_derivation(multisig, network):
         """Return the Krux default derivation path for single-sig or multisig"""
         return (DER_MULTI if multisig else DER_SINGLE) % network["bip32"]
+
+    @staticmethod
+    def get_default_derivation_str(multisig, network):
+        """Return the Krux default derivation path for single-sig or multisig to
+        be displayd as string
+        """
+        return Key.get_default_derivation(multisig, network).replace(
+            "h", HARDENED_STR_REPLACE
+        )

--- a/src/krux/pages/home.py
+++ b/src/krux/pages/home.py
@@ -229,6 +229,17 @@ class Home(Page):
                     % self.ctx.wallet.descriptor.to_string()
                 )
                 self.ctx.display.flash_text(t("Wallet output descriptor loaded!"))
+
+            # BlueWallet single sig descriptor without fingerprint
+            if (
+                self.ctx.wallet.descriptor.key
+                and not self.ctx.wallet.descriptor.key.origin
+            ):
+                self.ctx.display.clear()
+                self.ctx.display.draw_centered_text(
+                    t("Warning:\nIncomplete output descriptor"), theme.error_color
+                )
+                self.ctx.input.wait_for_button()
         except Exception as e:
             self.ctx.log.exception("Exception occurred loading wallet")
             self.ctx.display.clear()
@@ -236,14 +247,7 @@ class Home(Page):
                 t("Invalid wallet:\n%s") % repr(e), theme.error_color
             )
             self.ctx.input.wait_for_button()
-        if self.ctx.wallet.descriptor.key:  # If single sig
-            if not self.ctx.wallet.descriptor.key.origin:
-                # Blue exports descriptors without a fingerprint
-                self.ctx.display.clear()
-                self.ctx.display.draw_centered_text(
-                    t("Warning:\nIncomplete output descriptor"), theme.error_color
-                )
-                self.ctx.input.wait_for_button()
+
         return MENU_CONTINUE
 
     def addresses_menu(self):

--- a/src/krux/pages/home.py
+++ b/src/krux/pages/home.py
@@ -230,16 +230,17 @@ class Home(Page):
                 )
                 self.ctx.display.flash_text(t("Wallet output descriptor loaded!"))
 
-            # BlueWallet single sig descriptor without fingerprint
-            if (
-                self.ctx.wallet.descriptor.key
-                and not self.ctx.wallet.descriptor.key.origin
-            ):
-                self.ctx.display.clear()
-                self.ctx.display.draw_centered_text(
-                    t("Warning:\nIncomplete output descriptor"), theme.error_color
-                )
-                self.ctx.input.wait_for_button()
+                # BlueWallet single sig descriptor without fingerprint
+                if (
+                    self.ctx.wallet.descriptor.key
+                    and not self.ctx.wallet.descriptor.key.origin
+                ):
+                    self.ctx.display.clear()
+                    self.ctx.display.draw_centered_text(
+                        t("Warning:\nIncomplete output descriptor"), theme.error_color
+                    )
+                    self.ctx.input.wait_for_button()
+
         except Exception as e:
             self.ctx.log.exception("Exception occurred loading wallet")
             self.ctx.display.clear()

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -361,7 +361,7 @@ class Login(Page):
                 (
                     t("Single-sig")
                     + "\n"
-                    + Key.get_default_derivation(
+                    + Key.get_default_derivation_str(
                         False, NETWORKS[Settings().bitcoin.network]
                     ),
                     lambda: MENU_EXIT,
@@ -369,7 +369,7 @@ class Login(Page):
                 (
                     t("Multisig")
                     + "\n"
-                    + Key.get_default_derivation(
+                    + Key.get_default_derivation_str(
                         True, NETWORKS[Settings().bitcoin.network]
                     ),
                     lambda: MENU_EXIT,

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -310,6 +310,13 @@ class Login(Page):
             return MENU_CONTINUE
         self.ctx.display.clear()
 
+        # Test mnemonic Checksum verification before asking for passphrase
+        temp_key = Key(
+            mnemonic,
+            False,
+            NETWORKS[Settings().bitcoin.network],
+        )
+
         while True:
             submenu = Menu(
                 self.ctx,


### PR DESCRIPTION
* Test mnemonic checksum before asking for passphrase
* Avoid double Exception when one is already raised at load wallet output descriptor
* Changed the derivation path on screen to use apostrophe, following the majority of wallets (now shows: `m/84'/0'/0'/0` instead of `m/84h/0h/0h/0`)