### PR TITLE
Fix line breaker on text with multiple lines and exact match on the screen width

### DIFF
--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -198,7 +198,22 @@ class Display:
                     # is less than the amount of columns. If it's exactly equal,
                     # a newline will be implicit.
                     if len(words[-1]) < columns:
-                        words[-1] += "\n"
+                        add_new_line = True
+                        # check for exact match with 2 words
+                        if (
+                            len(words) > 1
+                            and len(words[-1]) + len(words[-2]) + 1 == columns
+                        ):
+                            add_new_line = False
+                        # check for exact match with 3 words
+                        if (
+                            len(words) > 2
+                            and len(words[-1]) + len(words[-2]) + len(words[-3]) + 2
+                            == columns
+                        ):
+                            add_new_line = False
+                        if add_new_line:
+                            words[-1] += "\n"
 
         num_words = len(words)
 

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -375,3 +375,9 @@ class Display:
         level = max(0, min(level, 8))
         val = (level + 7) << 4
         self.i2c.writeto_mem(0x34, 0x91, int(val))
+
+    def max_lines(self, line_offset=0):
+        """The max lines of text supported by the display"""
+        return (self.height() - 2 * DEFAULT_PADDING - line_offset) // (
+            2 * self.font_height
+        )

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -566,8 +566,7 @@ class Menu:
         self.menu = menu
         self.menu_offset = offset
         max_viewable = min(
-            (self.ctx.display.height() - 2 * DEFAULT_PADDING - self.menu_offset)
-            // (2 * self.ctx.display.font_height),
+            self.ctx.display.max_lines(self.menu_offset),
             len(self.menu),
         )
         self.menu_view = ListView(self.menu, max_viewable)

--- a/src/krux/pages/addresses.py
+++ b/src/krux/pages/addresses.py
@@ -32,7 +32,6 @@ from . import (
     MENU_EXIT,
 )
 
-LIST_ADDRESS_QTD = 4  # qtd of address per page
 SCAN_ADDRESS_LIMIT = 20
 
 
@@ -73,19 +72,21 @@ class Addresses(Page):
             if addr_type == 1:
                 loading_txt = t("Loading change address %d..")
 
+            max_addresses = self.ctx.display.max_lines() - 3
+
             num_checked = 0
             while True:
                 items = []
-                if num_checked + 1 > LIST_ADDRESS_QTD:
+                if num_checked + 1 > max_addresses:
                     items.append(
                         (
-                            "%d..%d" % (num_checked - LIST_ADDRESS_QTD, num_checked),
+                            "%d..%d" % (num_checked - max_addresses, num_checked),
                             lambda: MENU_EXIT,
                         )
                     )
 
                 for addr in self.ctx.wallet.obtain_addresses(
-                    num_checked, limit=LIST_ADDRESS_QTD, branch_index=addr_type
+                    num_checked, limit=max_addresses, branch_index=addr_type
                 ):
                     self.ctx.display.clear()
                     self.ctx.display.draw_centered_text(loading_txt % (num_checked + 1))
@@ -105,7 +106,7 @@ class Addresses(Page):
 
                 items.append(
                     (
-                        "%d..%d" % (num_checked + 1, num_checked + LIST_ADDRESS_QTD),
+                        "%d..%d" % (num_checked + 1, num_checked + max_addresses),
                         lambda: MENU_EXIT,
                     )
                 )
@@ -125,9 +126,9 @@ class Addresses(Page):
                     if index == len(submenu.menu) - 2:
                         stay_on_this_addr_menu = False
                     # Prev
-                    if index == 0 and num_checked > LIST_ADDRESS_QTD:
+                    if index == 0 and num_checked > max_addresses:
                         stay_on_this_addr_menu = False
-                        num_checked -= 2 * LIST_ADDRESS_QTD
+                        num_checked -= 2 * max_addresses
 
         return MENU_CONTINUE
 

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -303,7 +303,30 @@ class Login(Page):
             return MENU_CONTINUE
         return data
 
-    def _load_key_from_words(self, words):
+    def _get_words_numbers(self, words, charset):
+        word_numbers = []
+        for word in words:
+            word_numbers.append(WORDLIST.index(word) + 1)
+
+        if charset == DIGITS_HEX:
+            for i, number in enumerate(word_numbers):
+                word_numbers[i] = hex(number)[2:].upper()
+
+        if charset == DIGITS_OCT:
+            for i, number in enumerate(word_numbers):
+                word_numbers[i] = oct(number)[2:]
+
+        numbers_str = [str(value) for value in word_numbers]
+        return " ".join(numbers_str)
+
+    def _load_key_from_words(self, words, charset=LETTERS):
+        if charset != LETTERS:
+            numbers_str = self._get_words_numbers(words, charset)
+            self.display_mnemonic(numbers_str)
+            if not self.prompt(t("Continue?"), self.ctx.display.bottom_prompt_line):
+                return MENU_CONTINUE
+            self.ctx.display.clear()
+
         mnemonic = " ".join(words)
         self.display_mnemonic(mnemonic)
         if not self.prompt(t("Continue?"), self.ctx.display.bottom_prompt_line):
@@ -531,7 +554,7 @@ class Login(Page):
                 ):
                     words.append(word)
 
-            return self._load_key_from_words(words)
+            return self._load_key_from_words(words, charset)
 
         return MENU_CONTINUE
 

--- a/tests/pages/test_home.py
+++ b/tests/pages/test_home.py
@@ -277,7 +277,7 @@ def test_mnemonic_compact_qr(mocker, m5stickv, tdata):
     from krux.qr import FORMAT_NONE
 
     cases = [
-        # No print prompt
+        # 0 - No print prompt
         (
             Wallet(tdata.SINGLESIG_12_WORD_KEY),
             None,
@@ -286,13 +286,14 @@ def test_mnemonic_compact_qr(mocker, m5stickv, tdata):
                 BUTTON_PAGE,
                 BUTTON_ENTER,  # Open Compact SeedQR
                 BUTTON_ENTER,  # Leave
-                BUTTON_ENTER,  # Are you sure? yes
+                BUTTON_ENTER,  # Leave QR Viewer
                 BUTTON_PAGE_PREV,  # change to btn Back
                 BUTTON_PAGE_PREV,
                 BUTTON_PAGE_PREV,
                 BUTTON_ENTER,  # click on back to return to home init screen
             ],
         ),
+        # 1
         (
             Wallet(tdata.SINGLESIG_24_WORD_KEY),
             None,
@@ -301,14 +302,14 @@ def test_mnemonic_compact_qr(mocker, m5stickv, tdata):
                 BUTTON_PAGE,
                 BUTTON_ENTER,  # Open Compact SeedQR
                 BUTTON_ENTER,  # Leave
-                BUTTON_ENTER,  # Are you sure? yes
+                BUTTON_ENTER,  # Leave QR Viewer
                 BUTTON_PAGE_PREV,  # change to btn Back
                 BUTTON_PAGE_PREV,
                 BUTTON_PAGE_PREV,
                 BUTTON_ENTER,  # click on back to return to home init screen
             ],
         ),
-        # Print
+        # 2 - Print
         (
             Wallet(tdata.SINGLESIG_12_WORD_KEY),
             MockPrinter(),
@@ -317,14 +318,14 @@ def test_mnemonic_compact_qr(mocker, m5stickv, tdata):
                 BUTTON_PAGE,
                 BUTTON_ENTER,  # Open Compact SeedQR
                 BUTTON_ENTER,  # Leave
-                BUTTON_ENTER,  # Are you sure? yes
-                BUTTON_ENTER,  # say yes to print prompt
+                BUTTON_ENTER,  # Leave QR Viewer
                 BUTTON_PAGE_PREV,  # change to btn Back
                 BUTTON_PAGE_PREV,
                 BUTTON_PAGE_PREV,
                 BUTTON_ENTER,  # click on back to return to home init screen
             ],
         ),
+        # 3
         (
             Wallet(tdata.SINGLESIG_24_WORD_KEY),
             MockPrinter(),
@@ -333,15 +334,14 @@ def test_mnemonic_compact_qr(mocker, m5stickv, tdata):
                 BUTTON_PAGE,
                 BUTTON_ENTER,  # Open Compact SeedQR
                 BUTTON_ENTER,  # Leave
-                BUTTON_ENTER,  # Are you sure? yes
-                BUTTON_ENTER,  # say yes to print prompt
+                BUTTON_ENTER,  # Leave QR Viewer
                 BUTTON_PAGE_PREV,  # change to btn Back
                 BUTTON_PAGE_PREV,
                 BUTTON_PAGE_PREV,
                 BUTTON_ENTER,  # click on back to return to home init screen
             ],
         ),
-        # Decline to print
+        # 4 - Decline to print
         (
             Wallet(tdata.SINGLESIG_12_WORD_KEY),
             MockPrinter(),
@@ -350,14 +350,14 @@ def test_mnemonic_compact_qr(mocker, m5stickv, tdata):
                 BUTTON_PAGE,
                 BUTTON_ENTER,  # Open Compact SeedQR
                 BUTTON_ENTER,  # Leave
-                BUTTON_ENTER,  # Are you sure? yes
-                BUTTON_PAGE,  # say no to print prompt
+                BUTTON_ENTER,  # Leave QR Viewer
                 BUTTON_PAGE_PREV,  # change to btn Back
                 BUTTON_PAGE_PREV,
                 BUTTON_PAGE_PREV,
                 BUTTON_ENTER,  # click on back to return to home init screen
             ],
         ),
+        # 5
         (
             Wallet(tdata.SINGLESIG_24_WORD_KEY),
             MockPrinter(),
@@ -366,8 +366,7 @@ def test_mnemonic_compact_qr(mocker, m5stickv, tdata):
                 BUTTON_PAGE,
                 BUTTON_ENTER,  # Open Compact SeedQR
                 BUTTON_ENTER,  # Leave
-                BUTTON_ENTER,  # Are you sure? yes
-                BUTTON_PAGE,  # say no to print prompt
+                BUTTON_ENTER,  # Leave QR Viewer
                 BUTTON_PAGE_PREV,  # change to btn Back
                 BUTTON_PAGE_PREV,
                 BUTTON_PAGE_PREV,

--- a/tests/pages/test_home.py
+++ b/tests/pages/test_home.py
@@ -512,11 +512,11 @@ def test_public_key(mocker, m5stickv, tdata):
             Wallet(tdata.SINGLESIG_12_WORD_KEY),
             None,
             [
-                BUTTON_ENTER, # XPUB - Text
-                BUTTON_PAGE, # move Back - child
-                BUTTON_ENTER, # Press Back - child
-                BUTTON_PAGE_PREV, # Move Back - father
-                BUTTON_ENTER # Press Back - father
+                BUTTON_ENTER,  # XPUB - Text
+                BUTTON_PAGE,  # move Back - child
+                BUTTON_ENTER,  # Press Back - child
+                BUTTON_PAGE_PREV,  # Move Back - father
+                BUTTON_ENTER,  # Press Back - father
             ],
         ),
         # 1

--- a/tests/pages/test_home.py
+++ b/tests/pages/test_home.py
@@ -87,6 +87,7 @@ def create_ctx(mocker, btn_seq, wallet=None, printer=None, touch_seq=None):
     ctx = mock_context(mocker)
     ctx.power_manager.battery_charge_remaining.return_value = 1
     ctx.input.wait_for_button = mocker.MagicMock(side_effect=btn_seq)
+    ctx.display.max_lines = mocker.MagicMock(return_value=7)
 
     ctx.wallet = wallet
     ctx.printer = printer
@@ -611,6 +612,7 @@ def test_public_key(mocker, m5stickv, tdata):
                 "ZPUB",
             ),
         ]
+        # TODO: Fix here to match the changes on XPUB screen
         home.display_qr_codes.assert_has_calls(display_qr_calls)
         if case[1] is not None:
             home.utils.print_standard_qr.assert_has_calls(print_qr_calls)

--- a/tests/pages/test_home.py
+++ b/tests/pages/test_home.py
@@ -503,22 +503,29 @@ def test_mnemonic_st_qr_touch(mocker, amigo_tft, tdata):
 def test_public_key(mocker, m5stickv, tdata):
     from krux.pages.home import Home
     from krux.wallet import Wallet
-    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
     from krux.qr import FORMAT_NONE
 
     cases = [
-        # No print prompt
+        # 0 - No print prompt
         (
             Wallet(tdata.SINGLESIG_12_WORD_KEY),
             None,
-            [BUTTON_ENTER, BUTTON_ENTER, BUTTON_ENTER, BUTTON_ENTER],
+            [
+                BUTTON_ENTER, # XPUB - Text
+                BUTTON_PAGE, # move Back - child
+                BUTTON_ENTER, # Press Back - child
+                BUTTON_PAGE_PREV, # Move Back - father
+                BUTTON_ENTER # Press Back - father
+            ],
         ),
+        # 1
         (
             Wallet(tdata.MULTISIG_12_WORD_KEY),
             None,
             [BUTTON_ENTER, BUTTON_ENTER, BUTTON_ENTER, BUTTON_ENTER],
         ),
-        # Print
+        # 2 - Print
         (
             Wallet(tdata.SINGLESIG_12_WORD_KEY),
             MockPrinter(),
@@ -531,6 +538,7 @@ def test_public_key(mocker, m5stickv, tdata):
                 BUTTON_ENTER,
             ],
         ),
+        # 3
         (
             Wallet(tdata.MULTISIG_12_WORD_KEY),
             MockPrinter(),
@@ -543,7 +551,7 @@ def test_public_key(mocker, m5stickv, tdata):
                 BUTTON_ENTER,
             ],
         ),
-        # Decline to print
+        # 4 - Decline to print
         (
             Wallet(tdata.SINGLESIG_12_WORD_KEY),
             MockPrinter(),
@@ -556,6 +564,7 @@ def test_public_key(mocker, m5stickv, tdata):
                 BUTTON_PAGE,
             ],
         ),
+        # 5
         (
             Wallet(tdata.MULTISIG_12_WORD_KEY),
             MockPrinter(),
@@ -569,7 +578,10 @@ def test_public_key(mocker, m5stickv, tdata):
             ],
         ),
     ]
+    num = 0
     for case in cases:
+        print(num)
+        num += 1
         ctx = create_ctx(mocker, case[2], case[0], case[1])
         home = Home(ctx)
 

--- a/tests/pages/test_login.py
+++ b/tests/pages/test_login.py
@@ -1080,6 +1080,7 @@ def test_load_key_from_digits(m5stickv, mocker, mocker_printer):
             )
             + [
                 BUTTON_ENTER,  # Done?
+                BUTTON_ENTER,  # 12 numbers confirm
                 BUTTON_ENTER,  # 12 word confirm
                 BUTTON_PAGE,  # 1 press to move to Scan passphrase
                 BUTTON_PAGE,  # 1 press to move to No passphrase
@@ -1107,6 +1108,7 @@ def test_load_key_from_digits(m5stickv, mocker, mocker_printer):
             + [BUTTON_ENTER]
             + [
                 BUTTON_ENTER,  # Done?
+                BUTTON_ENTER,  # 12 numbers confirm
                 BUTTON_ENTER,  # 12 word confirm
                 BUTTON_PAGE,  # 1 press to move to Scan passphrase
                 BUTTON_PAGE,  # 1 press to move to No passphrase
@@ -1119,7 +1121,7 @@ def test_load_key_from_digits(m5stickv, mocker, mocker_printer):
     ]
     num = 0
     for case in cases:
-        print(num)
+        print("case:", num)
         num = num + 1
         ctx = create_ctx(mocker, case[0])
         login = Login(ctx)
@@ -1156,6 +1158,7 @@ def test_load_12w_from_hexadecimal(m5stickv, mocker, mocker_printer):
         )
         + [
             BUTTON_ENTER,  # Done?
+            BUTTON_ENTER,  # 12 numbers confirm
             BUTTON_ENTER,  # 12 word confirm
             BUTTON_PAGE,  # 1 press to move to Scan passphrase
             BUTTON_PAGE,  # 1 press to move to No passphrase
@@ -1223,6 +1226,7 @@ def test_possible_letters_from_hexadecimal(m5stickv, mocker, mocker_printer):
         )
         + [
             BUTTON_ENTER,  # Done?
+            BUTTON_ENTER,  # 12 numbers confirm
             BUTTON_ENTER,  # 12 word confirm
             BUTTON_PAGE,  # 1 press to move to Scan passphrase
             BUTTON_PAGE,  # 1 press to move to No passphrase
@@ -1268,6 +1272,7 @@ def test_load_12w_from_octal(m5stickv, mocker, mocker_printer):
         )
         + [
             BUTTON_ENTER,  # Done?
+            BUTTON_ENTER,  # 12 numbers confirm
             BUTTON_ENTER,  # 12 word confirm
             BUTTON_PAGE,  # 1 press to move to Scan passphrase
             BUTTON_PAGE,  # 1 press to move to No passphrase
@@ -1328,6 +1333,7 @@ def test_possible_letters_from_octal(m5stickv, mocker, mocker_printer):
         )
         + [
             BUTTON_ENTER,  # Done?
+            BUTTON_ENTER,  # 12 numbers confirm
             BUTTON_ENTER,  # 12 word confirm
             BUTTON_PAGE,  # 1 press to move to Scan passphrase
             BUTTON_PAGE,  # 1 press to move to No passphrase

--- a/tests/pages/test_qr_view.py
+++ b/tests/pages/test_qr_view.py
@@ -23,5 +23,5 @@ def test_load_qr_view(amigo_tft, mocker):
     ctx.input.wait_for_button = mocker.MagicMock(side_effect=BTN_SEQUENCE)
     data = "test code"
     seed_qr_view = SeedQRView(ctx, data=data, title="Test QR Code")
-    seed_qr_view.display_seed_qr()
+    seed_qr_view.display_qr()
     assert ctx.display.draw_qr_code.call_count == 8

--- a/tests/shared_mocks.py
+++ b/tests/shared_mocks.py
@@ -347,6 +347,7 @@ def mock_context(mocker):
                 width=mocker.MagicMock(return_value=135),
                 height=mocker.MagicMock(return_value=240),
                 to_lines=mocker.MagicMock(return_value=[""]),
+                max_lines=mocker.MagicMock(return_value=7),
             ),
         )
     elif board.config["type"] == "dock":
@@ -364,6 +365,7 @@ def mock_context(mocker):
                 width=mocker.MagicMock(return_value=240),
                 height=mocker.MagicMock(return_value=320),
                 to_lines=mocker.MagicMock(return_value=[""]),
+                max_lines=mocker.MagicMock(return_value=9),
             ),
         )
     elif board.config["type"].startswith("amigo"):
@@ -374,5 +376,6 @@ def mock_context(mocker):
                 width=mocker.MagicMock(return_value=320),
                 height=mocker.MagicMock(return_value=480),
                 to_lines=mocker.MagicMock(return_value=[""]),
+                max_lines=mocker.MagicMock(return_value=9),
             ),
         )

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -182,6 +182,9 @@ def test_to_lines(mocker, m5stickv):
 
     cases = [
         (135, "Two Words", ["Two Words"]),
+        (135, "Two  Words", ["Two  Words"]),
+        (135, "Two   Words", ["Two   Words"]),
+        (135, "Two        Words", ["Two        Words"]),
         (135, "Two\nWords", ["Two", "Words"]),
         (135, "Two\n\nWords", ["Two", "", "Words"]),
         (135, "Two\n\n\nWords", ["Two", "", "", "Words"]),
@@ -304,6 +307,40 @@ def test_to_lines(mocker, m5stickv):
         )
         d = Display()
         lines = d.to_lines(case[1])
+        assert lines == case[2]
+
+
+def test_to_lines_exact_match_amigo(mocker, amigo_tft):
+    from krux.display import Display
+
+    cases = [
+        (320, "01234 0123456789012345678", ["01234 0123456789012345678"]),
+        (320, "0123456789 01234567890 01234", ["0123456789", "01234567890 01234"]),
+        (320, "01234567890123456789012345", ["0123456789012345678901234", "5"]),
+        (
+            320,
+            "01234 0123456789012345678\n01234 0123456789012345678",
+            ["01234 0123456789012345678", "01234 0123456789012345678"],
+        ),
+        (
+            320,
+            "01 34 0123456789012345678\n01234 0123456789012345678",
+            ["01 34 0123456789012345678", "01234 0123456789012345678"],
+        ),
+        (
+            320,
+            "01 345 0123456789012345678\n01234 0123456789012345678",
+            ["01 345", "0123456789012345678", "01234 0123456789012345678"],
+        ),
+    ]
+    for case in cases:
+        mocker.patch(
+            "krux.display.lcd",
+            new=mocker.MagicMock(width=mocker.MagicMock(return_value=case[0])),
+        )
+        d = Display()
+        lines = d.to_lines(case[1])
+        print(lines)
         assert lines == case[2]
 
 


### PR DESCRIPTION
* Fix line breaker on text with multiple lines and exact match on the screen width
* New step to 12/24 word confirm when loading from digits (dec, oct, hex)
* Addresses page now shows more lines on big screens