### PR TITLE
If action is not confirmed return to Submenu

### DIFF
--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -158,6 +158,7 @@ class SettingsPage(Page):
             except:
                 pass
             self.ctx.power_manager.reboot()
+        return MENU_CONTINUE
 
     def _settings_exit_check(self):
         """Handler for the 'Back' on settings screen"""

--- a/src/krux/pages/tools.py
+++ b/src/krux/pages/tools.py
@@ -139,6 +139,7 @@ class Tools(Page):
             self.erase_spiffs()
             # Reboot so default settings take place and SPIFFS is formatted.
             self.ctx.power_manager.reboot()
+        return MENU_CONTINUE
 
     def print_test(self):
         """Handler for the 'Print Test QR' menu item"""


### PR DESCRIPTION
For "Factory Settings", if actions is not confirmed, it is displaying unnecessary "Your changes will be kept..." message.
For "Wipe Device", if action is not confirmed, it is returning to Main menu instead of Submenu.
