### PR TITLE
adjusted: font constant names, font range conditions

### DIFF
--- a/firmware/font/hextokff.py
+++ b/firmware/font/hextokff.py
@@ -36,10 +36,10 @@ DEFAULT_CODEPOINTS = [
 ]
 TRANSLATIONS_DIR = "../../i18n/translations"
 
-CHINESE_MIN_CODEPOINT = 0x4E00
-CHINESE_MAX_CODEPOINT = 0x9FFF
-KOREAN_MIN_CODEPOINT = 0xAC00
-KOREAN_MAX_CODEPOINT = 0xD7A3
+CHINESE_CODEPOINT_MIN = 0x4E00
+CHINESE_CODEPOINT_MAX = 0x9FFF
+KOREAN_CODEPOINT_MIN = 0xAC00
+KOREAN_CODEPOINT_MAX = 0xD7A3
 
 
 def hextokff(filename=None, width=None, height=None, wide_glyphs=None):
@@ -72,7 +72,10 @@ def hextokff(filename=None, width=None, height=None, wide_glyphs=None):
             for translation in translations.values():
                 for char in translation:
                     # If is Chinese or Korean codepoint
-                    if CHINESE_MIN_CODEPOINT <= ord(char) <= KOREAN_MAX_CODEPOINT:
+                    if (
+                        CHINESE_CODEPOINT_MIN <= ord(char) <= CHINESE_CODEPOINT_MAX
+                        or KOREAN_CODEPOINT_MIN <= ord(char) <= KOREAN_CODEPOINT_MAX
+                    ):
                         # only include if wide_glyphs is ko-KR
                         if wide_glyphs and current_translation in wide_glyphs:
                             used_codepoints.add(ord(char))

--- a/simulator/kruxsim/mocks/lcd.py
+++ b/simulator/kruxsim/mocks/lcd.py
@@ -34,8 +34,8 @@ COLOR_WHITE = (255, 255, 255)
 WIDTH = BOARD_CONFIG["lcd"]["width"]
 HEIGHT = BOARD_CONFIG["lcd"]["height"]
 
-CHINESE_MIN_CODEPOINT = 0x4E00
-CHINESE_MAX_CODEPOINT = 0x9FFF
+CHINESE_CODEPOINT_MIN = 0x4E00
+CHINESE_CODEPOINT_MAX = 0x9FFF
 KOREAN_CODEPOINT_MIN = 0xAC00
 KOREAN_CODEPOINT_MAX = 0xD7A3
 
@@ -148,12 +148,15 @@ def _is_x_flipped():
 
 def string_width_px(string):
     standard_width = BOARD_CONFIG["krux"]["display"]["font"][0]
-    ko_width = BOARD_CONFIG["krux"]["display"]["font_wide"][0]
+    wide_width = BOARD_CONFIG["krux"]["display"]["font_wide"][0]
     string_width = 0
 
     for c in string:
-        if CHINESE_MIN_CODEPOINT < ord(c) < KOREAN_CODEPOINT_MAX:
-            string_width += ko_width
+        if (
+            CHINESE_CODEPOINT_MIN <= ord(c) <= CHINESE_CODEPOINT_MAX
+            or KOREAN_CODEPOINT_MIN <= ord(c) <= KOREAN_CODEPOINT_MAX
+        ):
+            string_width += wide_width
         else:
             string_width += standard_width
 
@@ -161,15 +164,24 @@ def string_width_px(string):
 
 def string_has_wide_glyph(string):
     for c in string:
-        if CHINESE_MIN_CODEPOINT < ord(c) < KOREAN_CODEPOINT_MAX:
+        if (
+            CHINESE_CODEPOINT_MIN <= ord(c) <= CHINESE_CODEPOINT_MAX
+            or KOREAN_CODEPOINT_MIN <= ord(c) <= KOREAN_CODEPOINT_MAX
+        ):
             return True
     return False
 
 def is_wide(c):
-    return CHINESE_MIN_CODEPOINT < ord(c) < KOREAN_CODEPOINT_MAX
+    return (
+            CHINESE_CODEPOINT_MIN <= ord(c) <= CHINESE_CODEPOINT_MAX
+            or KOREAN_CODEPOINT_MIN <= ord(c) <= KOREAN_CODEPOINT_MAX
+    )
 
 def char_width(c):
-    if CHINESE_MIN_CODEPOINT < ord(c) < KOREAN_CODEPOINT_MAX:
+    if (
+        CHINESE_CODEPOINT_MIN <= ord(c) <= CHINESE_CODEPOINT_MAX
+        or KOREAN_CODEPOINT_MIN <= ord(c) <= KOREAN_CODEPOINT_MAX
+    ):
         return BOARD_CONFIG["krux"]["display"]["font_wide"][0]
     else:
         return BOARD_CONFIG["krux"]["display"]["font"][0]
@@ -244,8 +256,6 @@ def draw_string(x, y, s, color, bgcolor=COLOR_BLACK):
                             ),
                         )
                 x_position += char_width(c) if BOARD_CONFIG["type"] != "amigo" else -char_width(c)
-                
-
 
     color = rgb565torgb888(color)
     bgcolor = rgb565torgb888(bgcolor)

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -29,7 +29,7 @@ from .settings import THIN_SPACE
 DEFAULT_PADDING = 10
 MINIMAL_PADDING = 5
 FONT_WIDTH, FONT_HEIGHT = board.config["krux"]["display"]["font"]
-FONT_WIDTH_WIDE, FONT_HEIGHT_KO = board.config["krux"]["display"]["font_wide"]
+FONT_WIDTH_WIDE, FONT_HEIGHT_WIDE = board.config["krux"]["display"]["font_wide"]
 PORTRAIT, LANDSCAPE = [2, 3] if board.config["type"] == "cube" else [1, 2]
 QR_DARK_COLOR, QR_LIGHT_COLOR = (
     [16904, 61307] if board.config["type"] == "m5stickv" else [0, 6342]

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -2,6 +2,8 @@ TEST_QR = bytearray(
     b"\x7fn\xfd\x830\x08v9\xd6\xedj\xa0\xdbUU7\xc8\xa0\xe0_U\x7f\x00i\x00\xe3\xd61P\x08\xf5Q\xef^\xfe`\xe8\xc1\x7f\xdex\x936Y\x91\xb8\xeb\xd29c\xd5\xd4\x7f\x00\n#\xfe\xcd\xd7\rJ\x8e\xd9\xe5\xf8\xb9K\xe6x\x17\xb9\xca\xa0\x9a\x9a\x7f\xbb\x1b\x01"
 )
 
+CHINESE_CODEPOINT_MIN = 0x4E00
+CHINESE_CODEPOINT_MAX = 0x9FFF
 KOREAN_CODEPOINT_MIN = 0xAC00
 KOREAN_CODEPOINT_MAX = 0xD7A3
 
@@ -10,14 +12,17 @@ def string_width_px(string):
     import board
 
     standard_width = board.config["krux"]["display"]["font"][0]
-    ko_width = board.config["krux"]["display"]["font_wide"][0]
+    wide_width = board.config["krux"]["display"]["font_wide"][0]
     print("standard_width:", standard_width)
-    print("ko_width:", ko_width)
+    print("wide_width:", wide_width)
     string_width = 0
 
     for c in string:
-        if KOREAN_CODEPOINT_MIN < ord(c) < KOREAN_CODEPOINT_MAX:
-            string_width += ko_width
+        if (
+            CHINESE_CODEPOINT_MIN <= ord(c) <= CHINESE_CODEPOINT_MAX
+            or KOREAN_CODEPOINT_MIN <= ord(c) <= KOREAN_CODEPOINT_MAX
+        ):
+            string_width += wide_width
         else:
             string_width += standard_width
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Adjustments for pr_446:
* inclusive codepoint range checks for chinese range, then korean range, maybe more in the future?
* constant naming conventions inherited from odudex's MaixPy support for asian langs.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
