### PR TITLE
tolerate "H" for hard derivation in message signing

### DIFF
--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -74,7 +74,7 @@ class SignMessage(Utils):
         try:
             parts = derivation_path.split("/")
             return parts[0] == "m" and all(
-                p.endswith("'") or p.endswith("h") or p.isdigit() for p in parts[1:]
+                p[-1] in ("'hH") or p.isdigit() for p in parts[1:]
             )
         except:
             return False
@@ -85,9 +85,9 @@ class SignMessage(Utils):
         if len(parts) < 2:
             return None
 
-        if parts[2] in ["0'", "0h"]:
+        if parts[2] in ["0'", "0h", "0H"]:
             return NETWORKS[MAIN_TXT]
-        if parts[2] in ["1'", "1h"]:
+        if parts[2] in ["1'", "1h", "1H"]:
             return NETWORKS[TEST_TXT]
         return None
 
@@ -97,7 +97,7 @@ class SignMessage(Utils):
         if len(parts) < 2:
             return None
 
-        script_from_deriv = int(parts[1].strip("'").strip("h"))
+        script_from_deriv = int(parts[1].strip("'hH"))
         for script_name, script_number in SINGLESIG_SCRIPT_PURPOSE.items():
             if script_number == script_from_deriv:
                 return script_name

--- a/tests/pages/home_pages/test_sign_message_ui.py
+++ b/tests/pages/home_pages/test_sign_message_ui.py
@@ -249,7 +249,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Sign to QR code
                 BUTTON_ENTER,  # Check QR code
             ],
-            "signmessage m/84h/0h/0h/0/3 ascii:a test message with a colon ':' character.",
+            "signmessage m/84'/0h/0H/0/3 ascii:a test message with a colon ':' character.",
             None,
             False,
             "a test message with a colon ':' character.",
@@ -264,7 +264,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Sign to QR code
                 BUTTON_ENTER,  # Check QR code
             ],
-            "signmessage m/84h/1h/0h/0/3 ascii:A test message.",
+            "signmessage m/84'/1h/0H/0/3 ascii:A test message.",
             None,
             False,
             "A test message.",
@@ -279,7 +279,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Sign to QR code
                 BUTTON_ENTER,  # Check QR code
             ],
-            "signmessage m/86h/0h/0h/0/3 ascii:a test message with a colon ':' character.",
+            "signmessage m/86'/0h/0H/0/3 ascii:a test message with a colon ':' character.",
             None,
             False,
             "a test message with a colon ':' character.",
@@ -294,7 +294,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Sign to QR code
                 BUTTON_ENTER,  # Check QR code
             ],
-            "signmessage m/44h/0h/0h/0/3 ascii:a test message with a colon ':' character.",
+            "signmessage m/44'/0h/0H/0/3 ascii:a test message with a colon ':' character.",
             None,
             False,
             "a test message with a colon ':' character.",
@@ -309,7 +309,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Sign to QR code
                 BUTTON_ENTER,  # Check QR code
             ],
-            "signmessage m/49h/0h/0h/0/3 ascii:a test message with a colon ':' character.",
+            "signmessage m/49'/0h/0H/0/3 ascii:a test message with a colon ':' character.",
             None,
             False,
             "a test message with a colon ':' character.",
@@ -326,7 +326,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
                 # BUTTON_PAGE_PREV,  # Move to Go
                 BUTTON_ENTER,  # Go
             ],
-            "signmessage m/84h/0h/0h/0/3 ascii:A test message.",
+            "signmessage m/84'/0h/0H/0/3 ascii:A test message.",
             None,
             True,  # Sign to SD
             "A test message.",
@@ -347,7 +347,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Go
             ],
             None,
-            "A test message.\nm/84'/0'/0'/0/3\nP2WPKH",
+            "A test message.\nm/84'/0h/0H/0/3\nP2WPKH",
             True,  # Sign to SD
             "A test message.",
             "3. bc1qgl..cn3",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Noticed tolerance for different "hardened" derivation paths including "'" and "h" but not "H", just in case a message signing request comes in a file like:
```
Hello World from Sparrow 2.0.0 signed on krux pr_453
m/84'/1h/1H/0/20
P2WPKH
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
