### PR TITLE
Yahboom k210 developer kit

### DIFF
--- a/firmware/font/bdftokff.py
+++ b/firmware/font/bdftokff.py
@@ -39,17 +39,17 @@ WIDE24 = "NotoSansCJK-24"
 def open_bdf_save_kff(filename, width, height):
     """Open a bdf font filename and save the corresponding kff file based on the filename"""
 
-    filename_kff = "m5stickv_cube"
+    filename_kff = "tiny"
     if filename == FONT16:
-        filename_kff = "bit_dock_yahboom_wondermv"
+        filename_kff = "small"
     elif filename == FONT24:
-        filename_kff = "amigo"
+        filename_kff = "medium"
     elif filename == WIDE14:
-        filename_kff = "m5stickv_cube_wide"
+        filename_kff = "tiny_wide"
     elif filename == WIDE16:
-        filename_kff = "bit_dock_yahboom_wondermv_wide"
+        filename_kff = "small_wide"
     elif filename == WIDE24:
-        filename_kff = "amigo_wide"
+        filename_kff = "medium_wide"
 
     # Create hexfile based on bdf
     font_hex = "\n".join(bdftohex.bdftohex(filename + ".bdf")) + "\n"
@@ -88,21 +88,22 @@ def save_new_fontc(font_name, overwrite=False):
     on each project, based on the font_name passed otherwise save
     a new font.c file"""
 
-    filename_kff = "m5stickv_cube"
+    filename_kff = "tiny"
     device_name = "m5stickv"
     if font_name == FONT16:
-        filename_kff = "bit_dock_yahboom_wondermv"
+        filename_kff = "small"
         device_name = "dock"
     elif font_name == FONT24:
-        device_name = filename_kff = "amigo"
+        filename_kff = "medium"
+        device_name = "amigo"
     elif font_name == WIDE14:
-        filename_kff = "m5stickv_cube_wide"
+        filename_kff = "tiny_wide"
     elif font_name == WIDE16:
-        filename_kff = "bit_dock_yahboom_wondermv_wide"
+        filename_kff = "small_wide"
         device_name = "dock"
     elif font_name == WIDE24:
+        filename_kff = "medium_wide"
         device_name = "amigo"
-        filename_kff = "amigo_wide"
 
     maixpy_path_start = "../MaixPy/projects/maixpy_"
     maixpy_path_end = (
@@ -133,19 +134,12 @@ def save_new_fontc(font_name, overwrite=False):
         with open(filename, "w", encoding="utf-8", newline="\n") as save_file:
             save_file.write(unicode_str)
 
-        # Also replace for bit, yahboom, and wonder_mv
+        # Also replace for bit, yahboom, wonder_mv, and yahboom_devkit
         if font_name in (FONT16, WIDE16):
-            filename = maixpy_path_start + "bit" + maixpy_path_end
-            with open(filename, "w", encoding="utf-8", newline="\n") as save_file:
-                save_file.write(unicode_str)
-
-            filename = maixpy_path_start + "yahboom" + maixpy_path_end
-            with open(filename, "w", encoding="utf-8", newline="\n") as save_file:
-                save_file.write(unicode_str)
-
-            filename = maixpy_path_start + "wonder_mv" + maixpy_path_end
-            with open(filename, "w", encoding="utf-8", newline="\n") as save_file:
-                save_file.write(unicode_str)
+            for project in ["bit", "yahboom", "wonder_mv", "yahboom_devkit"]:
+                filename = maixpy_path_start + project + maixpy_path_end
+                with open(filename, "w", encoding="utf-8", newline="\n") as save_file:
+                    save_file.write(unicode_str)
 
         # Also replace for Cube
         if font_name in (FONT14, WIDE14):

--- a/krux
+++ b/krux
@@ -52,11 +52,21 @@ filesize() {
 
 if [ "$1" == "build" ]; then
     device="$2"
+    if [ "$device" == "--unsupported" ]; then
+        device="$3"
+        allow_unsupported="true"
+    fi
     if [ -z "$device" ]; then
         echo "Missing device"
     else
-        if [ "$device" == "maixpy_m5stickv" ]||[ "$device" == "maixpy_amigo" ]||[ "$device" == "maixpy_bit" ]||
-        [ "$device" == "maixpy_dock" ]||[ "$device" == "maixpy_yahboom" ]||[ "$device" == "maixpy_cube" ]||[ "$device" == "maixpy_wonder_mv" ]; then
+        if [ "$device" == "maixpy_m5stickv" ]||
+        [ "$device" == "maixpy_amigo" ]||
+        [ "$device" == "maixpy_bit" ]||
+        [ "$device" == "maixpy_dock" ]||
+        [ "$device" == "maixpy_yahboom" ]||
+        [ "$device" == "maixpy_cube" ]||
+        [ "$device" == "maixpy_wonder_mv" ]||
+        [ "$allow_unsupported" ]; then
             declare $(grep -m 1 version pyproject.toml | sed 's/ *= */=/g' | sed 's/"//g' | sed 's/\r//g')
             sed -i -- 's/VERSION = ".*"/VERSION = "'"$version"'"/g' src/krux/metadata.py
             
@@ -72,7 +82,7 @@ if [ "$1" == "build" ]; then
             docker cp extract-firmware:$BUILD_DIR/kboot.kfpkg build/kboot.kfpkg
             docker rm extract-firmware
         else
-            echo "Wrong device name, use maixpy_devicename"
+            echo "Wrong or unsupported device name, use maixpy_devicename"
         fi
     fi
 elif [ "$1" == "flash" ]; then
@@ -84,10 +94,14 @@ elif [ "$1" == "flash" ]; then
         if [ "$device" == "maixpy_m5stickv" ]; then
             # https://devicehunt.com/view/type/usb/vendor/0403/device/6001
             device_vendor_product_id="0403:6001"
-        elif [ "$device" == "maixpy_amigo" ]||[ "$device" == "maixpy_bit" ]||[ "$device" == "maixpy_cube" ]; then
+        elif [ "$device" == "maixpy_amigo" ]||
+        [ "$device" == "maixpy_bit" ]||
+        [ "$device" == "maixpy_cube" ]; then
             # https://devicehunt.com/view/type/usb/vendor/0403/device/6010
             device_vendor_product_id="0403:6010"
-        elif [ "$device" == "maixpy_dock" ]||[ "$device" == "maixpy_yahboom" ]||[ "$device" == "maixpy_wonder_mv" ]; then
+        elif [ "$device" == "maixpy_dock" ]||
+        [ "$device" == "maixpy_yahboom" ]||
+        [ "$device" == "maixpy_wonder_mv" ]; then
             # https://devicehunt.com/view/type/usb/vendor/1a86/device/7523
             device_vendor_product_id="1a86:7523"
         fi


### PR DESCRIPTION
### What is this PR for?
an experimental support for the Yahboom-K210-Developer-Kit board (larger than yahboom module, w/ exposed headers on front)

Note: serial port not yet resolved... have not been able to connect via terminal then interrupt or start repl (even when compiler is configured)???

Beware: this board contains wifi hardware that could be enabled if jumpers were left on connecting IO pins 13,14, and 15 to esp-wifi pins tx, rx, and en respectively.

This new unsupported board pretends to be "yahboom" so that krux code is not changed.
The `./krux` builder script would require building this board like `./krux build --unsupported maixpy_yahboom_devkit`.  It could later be flashed like a yahboom `./krux flash maixpy_yahboom` as long as it was the last binary built.

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other
