### PR TITLE
Tests that fail for BlueWallet-v7.0.7 upper-cased addresses

### DIFF
--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -993,6 +993,14 @@ def test_parse_address(mocker, m5stickv, tdata):
             "bc1qx2zuday8d6j4ufh4df6e9ttd06lnfmn2cuz0vn",
         ),
         (
+            "bitcoin:BC1QX2ZUDAY8D6J4UFH4DF6E9TTD06LNFMN2CUZ0VN?message=test",
+            "bc1qx2zuday8d6j4ufh4df6e9ttd06lnfmn2cuz0vn",
+        ),
+        (
+            "BITCOIN:BC1QX2ZUDAY8D6J4UFH4DF6E9TTD06LNFMN2CUZ0VN?message=test",
+            "bc1qx2zuday8d6j4ufh4df6e9ttd06lnfmn2cuz0vn",
+        ),
+        (
             "bitcoin:32iCX1pY1iztdgM5qzurGLPMu5xhNfAUtg?message=test",
             "32iCX1pY1iztdgM5qzurGLPMu5xhNfAUtg",
         ),


### PR DESCRIPTION
### What is this PR for?
1 commit that adds failing tests for latest BlueWallet v7.0.7 bech32 addresses that look like "bitcoin:BC1Q..."

TODO: resolve wallet.parse_address??? to support uppercased bech32 addresses and avoids future BlueWallet user complaints about not being able to verify addresses.



### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
